### PR TITLE
Switch from gunicorn to django server in development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,2 @@
 FROM heroku/python:3
+ENV PYTHONUNBUFFERED 1

--- a/bin/start-api
+++ b/bin/start-api
@@ -5,4 +5,4 @@
 sleep 3
 
 python manage.py migrate
-gunicorn lighten.wsgi --reload --workers 2
+python manage.py runserver 0.0.0.0:${PORT}

--- a/lighten/settings.py
+++ b/lighten/settings.py
@@ -22,7 +22,7 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.pop('SECRET_KEY')
+SECRET_KEY = os.environ['SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ gunicorn==19.6.0
 itypes==1.1.0
 Markdown==2.6.6
 psycopg2==2.6.2
+pyinotify==0.9.6
 PyJWT==1.4.2
 requests==2.11.0
 simplejson==3.8.2


### PR DESCRIPTION
Gunicorn has been having random hangs that make development frustrating.
Given it's really meant for use in production, just switch to the
django development server instead. This matches well with the docker
compose doc at https://docs.docker.com/compose/django/.

Notes:
- Since runserver makes two passes through settings.py, we need to leave
  SECRET_KEY in the environment. This is slightly risky in production
  since it could lead to environment leakage, but I think it's
  acceptable.
- The addition of PYTHONUNBUFFERED allows container output to work
  properly, see https://github.com/docker/compose/pull/2331 (it's not
  fixed as they claim)
- The addition of pyinotify makes detection of changed files more
  efficient, see
  https://docs.djangoproject.com/en/1.10/ref/django-admin/#runserver