### PR TITLE
Set test request default format to json

### DIFF
--- a/lighten/settings.py
+++ b/lighten/settings.py
@@ -150,7 +150,8 @@ REST_FRAMEWORK = {
         # TODO: Switch this to IsAuthenticated when ready
         'rest_framework.permissions.AllowAny',
     ],
-    'PAGE_SIZE': 100
+    'PAGE_SIZE': 100,
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json'
 }
 
 JWT_AUTH = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django==1.10.2
 django-crispy-forms==1.6.0
 django-filter==0.15.2
 django-guardian==1.4.6
--e git://github.com/andreyrusanov/django-rest-assured.git@643a20eb519fbd5d5c0e433c3bccc3b79033552b#egg=django_rest_assured
+django-rest-assured==0.2.0
 djangorestframework==3.4.7
 djangorestframework-jwt==1.8.0
 factory-boy==2.7.0


### PR DESCRIPTION
This removes the need for the django-rest-assured fork.

http://www.django-rest-framework.org/api-guide/testing/#setting-the-default-format